### PR TITLE
Use heart-beat setting in headers

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -145,7 +145,10 @@ class Client {
         this.ws.onopen = () => {
             this.debug('Web Socket Opened...');
             headers['accept-version'] = VERSIONS.supportedVersions();
-            headers['heart-beat'] = [this.heartbeat.outgoing, this.heartbeat.incoming].join(',');
+            // Check if we already have heart-beat in headers before adding them
+            if (!headers['heart-beat']) {
+                headers['heart-beat'] = [this.heartbeat.outgoing, this.heartbeat.incoming].join(',');
+            }
             this._transmit('CONNECT', headers);
         };
     }


### PR DESCRIPTION
Add check to see if user has already included heart beat information in headers before adding default values.

This functionality is needed when using the `over` method for creating the client.
