### PR TITLE
Fix strictNullChecks incompatibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -80,7 +80,7 @@ export interface ConnectionHeaders {
   login?: string;
   passcode?: string;
   host?: string;
-  [key: string]: string;
+  [key: string]: string | undefined;
 }
 
 export interface DisconnectHeaders {


### PR DESCRIPTION
The ConnectionHeaders interface does not work with `strict: true` or `strictNullChecks: true`.

Though this point needs further investigation on TypeScript itself, this should help to have type suggestions on ConnectionHeaders in strict mode.

If this isn't consistent enough the only solution (afaik) is to remove the optional keys and the undefined key definition. In this case you will lose the type suggestion:

```
export interface ConnectionHeaders {
  [key: string]: string;
}
```

Related to: https://github.com/Microsoft/TypeScript/issues/17277

If you agree to these changes, dont forget to bump the version 🥇 
