### PR TITLE
Added missing type for Client onreceipt

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,6 +36,8 @@ export class Client {
   nack(messageID: string, subscription: Subscription, headers?: NackHeaders): void;
 
   debug(...args: any[]): void;
+
+  onreceipt?(frame: Frame): void;
 }
 
 export class Frame {


### PR DESCRIPTION
Added missing type for client onreceipt.

See source code client.js

```
client.onreceipt = function(frame) {
//       receiptID = frame.headers['receipt-id'];
//       ...
}
```